### PR TITLE
add asset picture upload to asset items

### DIFF
--- a/src/AIMS.Core/Entities/AssetItem.cs
+++ b/src/AIMS.Core/Entities/AssetItem.cs
@@ -31,6 +31,8 @@ public class AssetItem : BaseEntity
     public AssetPriority Priority { get; set; }
     public IntegrityStatus IntegrityStatus { get; set; } 
     public List<AssetItemRemarks> AssetItemRemarks { get; set; }
+    [MaxLength(500)]
+    public string? PicturePath { get; set; }
 
     public void UpdateStatus(IntegrityStatus status)
     {

--- a/src/AIMS.Infrastructure/Migrations/20260519120651_AddAssetItemPicture.Designer.cs
+++ b/src/AIMS.Infrastructure/Migrations/20260519120651_AddAssetItemPicture.Designer.cs
@@ -4,6 +4,7 @@ using AIMS.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AIMS.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260519120651_AddAssetItemPicture")]
+    partial class AddAssetItemPicture
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/AIMS.Infrastructure/Migrations/20260519120651_AddAssetItemPicture.cs
+++ b/src/AIMS.Infrastructure/Migrations/20260519120651_AddAssetItemPicture.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AIMS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAssetItemPicture : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "PicturePath",
+                table: "AssetItems",
+                type: "nvarchar(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PicturePath",
+                table: "AssetItems");
+        }
+    }
+}

--- a/src/AIMS.WebFrontend/Pages/Account/Logout.cshtml.cs
+++ b/src/AIMS.WebFrontend/Pages/Account/Logout.cshtml.cs
@@ -39,11 +39,6 @@ public class LogoutModel : PageModel
 
         await _signInManager.SignOutAsync();
 
-        if (returnUrl != null)
-        {
-            return LocalRedirect(returnUrl);
-        }
-
-        return RedirectToPage();
+        return RedirectToPage("/Account/Login");
     }
 }

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Create.cshtml
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Create.cshtml
@@ -10,7 +10,7 @@
         <h1>Create New Asset Item</h1>
         <hr />
 
-        <form method="post" class="needs-validation">
+        <form method="post" enctype="multipart/form-data" class="needs-validation">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
 
             <div class="mb-3">
@@ -81,6 +81,12 @@
                         <span asp-validation-for="Input.IntegrityStatus" class="d-block mt-1 text-danger"></span>
                     </div>
                 </div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Input.Picture" class="form-label">Picture <span class="text-muted small">(optional — jpg, png, gif, webp, max 2 MB)</span></label>
+                <input asp-for="Input.Picture" type="file" class="form-control" accept=".jpg,.jpeg,.png,.gif,.webp" />
+                <span asp-validation-for="Input.Picture" class="text-danger small"></span>
             </div>
 
             <div class="form-group mt-4">

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Create.cshtml.cs
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Create.cshtml.cs
@@ -13,25 +13,53 @@ public class CreateModel : PageModel
 {
     private readonly AppDbContext _context;
     private readonly IActivityLogger _activityLogger;
+    private readonly IWebHostEnvironment _env;
 
-    public CreateModel(AppDbContext context, IActivityLogger activityLogger)
+    private static readonly string[] AllowedExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
+
+    public CreateModel(AppDbContext context, IActivityLogger activityLogger, IWebHostEnvironment env)
     {
         _context = context;
         _activityLogger = activityLogger;
+        _env = env;
     }
 
     [BindProperty]
     public CreateAssetItemInput Input { get; set; } = new();
 
-    public void OnGet()
-    {
-    }
+    public void OnGet() { }
 
     public async Task<IActionResult> OnPostAsync()
     {
         if (!ModelState.IsValid)
-        {
             return Page();
+
+        string? picturePath = null;
+
+        if (Input.Picture != null && Input.Picture.Length > 0)
+        {
+            if (Input.Picture.Length > 2 * 1024 * 1024)
+            {
+                ModelState.AddModelError("Input.Picture", "File size must not exceed 2 MB.");
+                return Page();
+            }
+
+            var ext = Path.GetExtension(Input.Picture.FileName).ToLowerInvariant();
+            if (!AllowedExtensions.Contains(ext))
+            {
+                ModelState.AddModelError("Input.Picture", "Only image files (.jpg, .jpeg, .png, .gif, .webp) are allowed.");
+                return Page();
+            }
+
+            var dir = Path.Combine(_env.WebRootPath, "asset-pictures");
+            Directory.CreateDirectory(dir);
+            var fileName = $"{Guid.NewGuid()}{ext}";
+            var filePath = Path.Combine(dir, fileName);
+
+            using var stream = new FileStream(filePath, FileMode.Create);
+            await Input.Picture.CopyToAsync(stream);
+
+            picturePath = $"/asset-pictures/{fileName}";
         }
 
         var assetItem = new AssetItem
@@ -42,13 +70,13 @@ public class CreateModel : PageModel
             Type = Input.Type,
             Location = Input.Location,
             Priority = Input.Priority,
-            IntegrityStatus = Input.IntegrityStatus
+            IntegrityStatus = Input.IntegrityStatus,
+            PicturePath = picturePath
         };
 
         _context.AssetItems.Add(assetItem);
         await _context.SaveChangesAsync();
 
-        // Log activity
         await _activityLogger.LogActivityAsync(
             "AssetItemCreated",
             $"Asset item '{assetItem.Title}' created",
@@ -83,5 +111,7 @@ public class CreateModel : PageModel
 
         [Required]
         public IntegrityStatus IntegrityStatus { get; set; }
+
+        public IFormFile? Picture { get; set; }
     }
 }

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Delete.cshtml.cs
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Delete.cshtml.cs
@@ -12,16 +12,20 @@ public class DeleteModel : PageModel
 {
     private readonly AppDbContext _context;
     private readonly IActivityLogger _activityLogger;
+    private readonly IWebHostEnvironment _env;
 
-    public DeleteModel(AppDbContext context, IActivityLogger activityLogger)
+    public DeleteModel(AppDbContext context, IActivityLogger activityLogger, IWebHostEnvironment env)
     {
         _context = context;
         _activityLogger = activityLogger;
+        _env = env;
     }
 
     public async Task<IActionResult> OnPostAsync(int id)
     {
-        var assetItem = await _context.AssetItems.FirstOrDefaultAsync(a => a.Id == id);
+        var assetItem = await _context.AssetItems
+            .Include(a => a.AssetItemRemarks)
+            .FirstOrDefaultAsync(a => a.Id == id);
 
         if (assetItem == null)
         {
@@ -29,6 +33,15 @@ public class DeleteModel : PageModel
         }
 
         var assetItemTitle = assetItem.Title;
+
+        if (!string.IsNullOrEmpty(assetItem.PicturePath))
+        {
+            var oldFile = Path.Combine(_env.WebRootPath, assetItem.PicturePath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+            if (System.IO.File.Exists(oldFile))
+                System.IO.File.Delete(oldFile);
+        }
+
+        _context.AssetRemarks.RemoveRange(assetItem.AssetItemRemarks);
         _context.AssetItems.Remove(assetItem);
         await _context.SaveChangesAsync();
 

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Details.cshtml
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Details.cshtml
@@ -157,6 +157,15 @@
             <div class="detail-label">Description</div>
             <div class="detail-value">@(string.IsNullOrEmpty(Model.AssetItem.Description) ? "-" : Model.AssetItem.Description)</div>
         </div>
+        @if (!string.IsNullOrEmpty(Model.AssetItem.PicturePath))
+        {
+            <div class="detail-row">
+                <div class="detail-label">Picture</div>
+                <div class="detail-value">
+                    <img src="@Model.AssetItem.PicturePath" alt="Asset picture" class="img-fluid rounded" style="max-height: 300px;" />
+                </div>
+            </div>
+        }
     </div>
 </div>
 
@@ -254,7 +263,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <form method="post" asp-page="Delete" asp-route-id="@Model.AssetItem.Id" style="display:inline;">
+                    <form method="post" asp-page-handler="Delete" asp-route-id="@Model.AssetItem.Id" style="display:inline;">
                         <button type="submit" class="btn btn-danger">Delete</button>
                     </form>
                 </div>

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Details.cshtml.cs
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Details.cshtml.cs
@@ -45,6 +45,37 @@ public class DetailsModel : PageModel
         return Page();
     }
 
+    public async Task<IActionResult> OnPostDeleteAsync(int id)
+    {
+        if (!User.IsInRole("Admin") && !User.IsInRole("Manager"))
+        {
+            return Forbid();
+        }
+
+        var assetItem = await _context.AssetItems
+            .Include(a => a.AssetItemRemarks)
+            .FirstOrDefaultAsync(a => a.Id == id);
+
+        if (assetItem == null)
+        {
+            return NotFound();
+        }
+
+        var assetItemTitle = assetItem.Title;
+        _context.AssetRemarks.RemoveRange(assetItem.AssetItemRemarks);
+        _context.AssetItems.Remove(assetItem);
+        await _context.SaveChangesAsync();
+
+        await _activityLogger.LogActivityAsync(
+            "AssetItemDeleted",
+            $"Asset item '{assetItemTitle}' deleted",
+            "AssetItem",
+            id.ToString()
+        );
+
+        return RedirectToPage("Index");
+    }
+
     public async Task<IActionResult> OnPostAsync(int id)
     {
         // Only Admin and Manager can add remarks, but Users can also add remarks (view-only doesn't mean can't comment)

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Edit.cshtml
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Edit.cshtml
@@ -10,9 +10,7 @@
         <h1>Edit Asset Item</h1>
         <hr />
 
-        <form method="post" class="needs-validation">
-            <input type="hidden" asp-for="AssetItemId" />
-
+        <form method="post" enctype="multipart/form-data" class="needs-validation">
             <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
 
             <div class="mb-3">
@@ -83,6 +81,19 @@
                         <span asp-validation-for="Input.IntegrityStatus" class="d-block mt-1 text-danger"></span>
                     </div>
                 </div>
+            </div>
+
+            <div class="mb-3">
+                <label asp-for="Input.Picture" class="form-label">Picture <span class="text-muted small">(optional — jpg, png, gif, webp, max 2 MB)</span></label>
+                @if (!string.IsNullOrEmpty(Model.ExistingPicturePath))
+                {
+                    <div class="mb-2">
+                        <img src="@Model.ExistingPicturePath" alt="Current picture" class="img-thumbnail" style="max-height: 150px;" />
+                        <small class="d-block text-muted mt-1">Upload a new file to replace the current picture.</small>
+                    </div>
+                }
+                <input asp-for="Input.Picture" type="file" class="form-control" accept=".jpg,.jpeg,.png,.gif,.webp" />
+                <span asp-validation-for="Input.Picture" class="text-danger small"></span>
             </div>
 
             <div class="form-group mt-4">

--- a/src/AIMS.WebFrontend/Pages/AssetItems/Edit.cshtml.cs
+++ b/src/AIMS.WebFrontend/Pages/AssetItems/Edit.cshtml.cs
@@ -14,28 +14,30 @@ public class EditModel : PageModel
 {
     private readonly AppDbContext _context;
     private readonly IActivityLogger _activityLogger;
+    private readonly IWebHostEnvironment _env;
 
-    public EditModel(AppDbContext context, IActivityLogger activityLogger)
+    private static readonly string[] AllowedExtensions = [".jpg", ".jpeg", ".png", ".gif", ".webp"];
+
+    public EditModel(AppDbContext context, IActivityLogger activityLogger, IWebHostEnvironment env)
     {
         _context = context;
         _activityLogger = activityLogger;
+        _env = env;
     }
 
     [BindProperty]
     public EditAssetItemInput Input { get; set; } = new();
 
-    public int AssetItemId { get; set; }
+    public string? ExistingPicturePath { get; set; }
 
     public async Task<IActionResult> OnGetAsync(int id)
     {
         var assetItem = await _context.AssetItems.FirstOrDefaultAsync(a => a.Id == id);
 
         if (assetItem == null)
-        {
             return NotFound();
-        }
 
-        AssetItemId = assetItem.Id;
+        ExistingPicturePath = assetItem.PicturePath;
         Input = new EditAssetItemInput
         {
             Title = assetItem.Title,
@@ -50,18 +52,50 @@ public class EditModel : PageModel
         return Page();
     }
 
-    public async Task<IActionResult> OnPostAsync()
+    public async Task<IActionResult> OnPostAsync(int id)
     {
-        if (!ModelState.IsValid)
-        {
-            return Page();
-        }
-
-        var assetItem = await _context.AssetItems.FirstOrDefaultAsync(a => a.Id == AssetItemId);
+        var assetItem = await _context.AssetItems.FirstOrDefaultAsync(a => a.Id == id);
 
         if (assetItem == null)
-        {
             return NotFound();
+
+        ExistingPicturePath = assetItem.PicturePath;
+
+        if (!ModelState.IsValid)
+            return Page();
+
+        if (Input.Picture != null && Input.Picture.Length > 0)
+        {
+            if (Input.Picture.Length > 2 * 1024 * 1024)
+            {
+                ModelState.AddModelError("Input.Picture", "File size must not exceed 2 MB.");
+                return Page();
+            }
+
+            var ext = Path.GetExtension(Input.Picture.FileName).ToLowerInvariant();
+            if (!AllowedExtensions.Contains(ext))
+            {
+                ModelState.AddModelError("Input.Picture", "Only image files (.jpg, .jpeg, .png, .gif, .webp) are allowed.");
+                return Page();
+            }
+
+            // Delete old picture if present
+            if (!string.IsNullOrEmpty(assetItem.PicturePath))
+            {
+                var oldFile = Path.Combine(_env.WebRootPath, assetItem.PicturePath.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+                if (System.IO.File.Exists(oldFile))
+                    System.IO.File.Delete(oldFile);
+            }
+
+            var dir = Path.Combine(_env.WebRootPath, "asset-pictures");
+            Directory.CreateDirectory(dir);
+            var fileName = $"{Guid.NewGuid()}{ext}";
+            var filePath = Path.Combine(dir, fileName);
+
+            using var stream = new FileStream(filePath, FileMode.Create);
+            await Input.Picture.CopyToAsync(stream);
+
+            assetItem.PicturePath = $"/asset-pictures/{fileName}";
         }
 
         var originalTitle = assetItem.Title;
@@ -76,7 +110,6 @@ public class EditModel : PageModel
         _context.AssetItems.Update(assetItem);
         await _context.SaveChangesAsync();
 
-        // Log activity
         await _activityLogger.LogActivityAsync(
             "AssetItemUpdated",
             $"Asset item '{originalTitle}' updated to '{assetItem.Title}'",
@@ -111,5 +144,7 @@ public class EditModel : PageModel
 
         [Required]
         public IntegrityStatus IntegrityStatus { get; set; }
+
+        public IFormFile? Picture { get; set; }
     }
 }

--- a/src/AIMS.WebFrontend/Pages/Index.cshtml.cs
+++ b/src/AIMS.WebFrontend/Pages/Index.cshtml.cs
@@ -1,8 +1,10 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace AIMS.WebFrontend.Pages
 {
+    [Authorize]
     public class IndexModel : PageModel
     {
         private readonly ILogger<IndexModel> _logger;


### PR DESCRIPTION
- PicturePath field on AssetItem entity with EF migration
- File upload on Create/Edit (jpg, png, gif, webp, max 2 MB)
- Edit shows current picture thumbnail; replaces and deletes old file on disk
- Delete cleans up picture file from wwwroot/asset-pictures/
- Details page displays picture when present
- Edit validation failure preserves existing picture thumbnail